### PR TITLE
fix: generate correct gui-version on build

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -41,12 +41,18 @@ jobs:
             latest=false
           tags: type=sha
 
+      - name: Extract GUI version
+        id: gui
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: echo "::set-output name=version::${TAGS##*:}"
+        
       - name: Build and push Docker image
         uses: docker/build-push-action@v3
         with:
           context: .
           push: true
           build-args: |
-            GUI_VERSION=${{ steps.meta.outputs.tags }}
+            GUI_VERSION=${{ steps.gui.outputs.version }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -56,3 +56,4 @@ jobs:
             GUI_VERSION=${{ steps.gui.outputs.version }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -46,7 +46,7 @@ jobs:
         env:
           TAGS: ${{ steps.meta.outputs.tags }}
         run: echo "::set-output name=version::${TAGS##*:}"
-        
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v3
         with:


### PR DESCRIPTION
This PR solves the issue where gui-version was not correctly set when building image