### PR TITLE
Create multiple multiview outputs per production

### DIFF
--- a/src/api/agileLive/pipelines/streams/streams.ts
+++ b/src/api/agileLive/pipelines/streams/streams.ts
@@ -5,6 +5,7 @@ import {
   SourceToPipelineStream,
   SourceWithId
 } from '../../../../interfaces/Source';
+import { MultiviewSettings } from '../../../../interfaces/multiview';
 import { PipelineStreamSettings } from '../../../../interfaces/pipeline';
 import { Production } from '../../../../interfaces/production';
 import { Result } from '../../../../interfaces/result';
@@ -200,11 +201,32 @@ export async function createStream(
     const multiviews = await getMultiviewsForPipeline(
       production.production_settings.pipelines[0].pipeline_id
     );
-    const multiview = multiviews.find(
-      (multiview) =>
-        multiview.id ===
-        production.production_settings.pipelines[0].multiview?.multiview_id
-    );
+    // ! What is the consequence of this? Cannot see the effect ->
+    // const multiview = multiviews.find(
+    //   (multiview) =>
+    //     multiview.id ===
+    //     production.production_settings.pipelines[0].multiview?.multiview_id
+    // );
+
+    // filter instead of find
+    const multiview = multiviews.find((multiview) => {
+      const pipeline = production.production_settings.pipelines[0];
+      const multiviewArray = pipeline.multiview;
+
+      if (Array.isArray(multiviewArray)) {
+        return multiviewArray.some(
+          (item) => item.multiview_id === multiview.id
+        );
+      } else if (multiviewArray) {
+        return (
+          (multiviewArray as MultiviewSettings).multiview_id === multiview.id
+        );
+      }
+
+      return false;
+    });
+    // ! <-
+
     if (!multiview) {
       Log().error(
         `No multiview found for pipeline: ${production.production_settings.pipelines[0].pipeline_id}`

--- a/src/api/manager/workflow.ts
+++ b/src/api/manager/workflow.ts
@@ -679,8 +679,15 @@ export async function startProduction(
     Log().info(
       `Production '${production.name}' with preset '${production_settings.name}' started`
     );
-    production.production_settings.pipelines[0].multiview.multiview_id =
-      multiviewId;
+    // ! What is the consequence of this? Cannot see the effect ->
+    // production.production_settings.pipelines[0].multiview.multiview_id =
+    //   multiviewId;
+    production.production_settings.pipelines[0].multiview.map(
+      (singleMultiview) => {
+        return (singleMultiview.multiview_id = multiviewId);
+      }
+    );
+    // ! <-
   } catch (e) {
     Log().error('Could not start multiviews');
     Log().error(e);

--- a/src/app/api/manager/streams/[id]/route.ts
+++ b/src/app/api/manager/streams/[id]/route.ts
@@ -18,13 +18,13 @@ export async function DELETE(
     });
   }
   const body = await request.json();
-  const multiview = body.multiview as MultiviewSettings;
+  const multiview = body.multiview as MultiviewSettings[];
   try {
     await deleteStream(params.id).catch((e) => {
       Log().error(`Failed to delete stream: ${params.id}: ${e.message}`);
       throw `Failed to delete stream: ${params.id}: ${e.message}`;
     });
-    if (!multiview) {
+    if (!multiview || multiview.length === 0) {
       return new NextResponse(
         JSON.stringify({
           ok: true,
@@ -68,17 +68,34 @@ export async function DELETE(
     );
   }
   try {
-    if (!multiview.multiview_id) {
-      throw `The provided multiview settings did not contain any multiview id`;
-    }
+    // ! What is the consequence of this? Cannot see the effect ->
+    // if (!multiview.multiview_id) {
+    //   throw `The provided multiview settings did not contain any multiview id`;
+    // }
 
-    await updateMultiviewForPipeline(
-      body.pipelineUUID,
-      multiview.multiview_id,
-      multiview.layout.views
-    ).catch((e) => {
-      throw `Error when updating multiview: ${e.message}`;
+    // await updateMultiviewForPipeline(
+    //   body.pipelineUUID,
+    //   multiview.multiview_id,
+    //   multiview.layout.views
+    // ).catch((e) => {
+    //   throw `Error when updating multiview: ${e.message}`;
+
+    const multiviewUpdates = multiview.map(async (singleMultiview) => {
+      if (!singleMultiview.multiview_id) {
+        throw `The provided multiview settings did not contain any multiview id`;
+      }
+      return updateMultiviewForPipeline(
+        body.pipelineUUID,
+        singleMultiview.multiview_id,
+        singleMultiview.layout.views
+      ).catch((e) => {
+        throw `Error when updating multiview: ${e.message}`;
+      });
     });
+
+    await Promise.all(multiviewUpdates);
+    // ! <-
+
     return new NextResponse(
       JSON.stringify({
         ok: true,

--- a/src/components/modal/configureOutputModal/MultiviewSettings.tsx
+++ b/src/components/modal/configureOutputModal/MultiviewSettings.tsx
@@ -3,7 +3,6 @@ import { useMultiviewPresets } from '../../../hooks/multiviewPreset';
 import { useTranslate } from '../../../i18n/useTranslate';
 import { MultiviewSettings } from '../../../interfaces/multiview';
 import { MultiviewPreset } from '../../../interfaces/preset';
-
 import Input from './Input';
 import Options from './Options';
 import toast from 'react-hot-toast';
@@ -13,29 +12,34 @@ type MultiviewSettingsProps = {
   handleUpdateMultiview: (multiview: MultiviewSettings) => void;
 };
 
-export default function MultiviewOutputSettings({
+export default function MultiviewSettingsConfig({
   multiview,
   handleUpdateMultiview
 }: MultiviewSettingsProps) {
   const t = useTranslate();
   const [multiviewPresets, loading] = useMultiviewPresets();
-  const [selectedMultiviewPreset, setetSelectedMultiviewPreset] = useState<
+  const [selectedMultiviewPreset, setSelectedMultiviewPreset] = useState<
     MultiviewPreset | undefined
   >(multiview);
+
   useEffect(() => {
     if (multiview) {
-      setetSelectedMultiviewPreset(multiview);
+      setSelectedMultiviewPreset(multiview);
       return;
     }
     if (multiviewPresets && multiviewPresets[0]) {
-      setetSelectedMultiviewPreset(multiviewPresets[0]);
+      setSelectedMultiviewPreset(multiviewPresets[0]);
     }
   }, [multiviewPresets, multiview]);
+
   if (!multiview) {
     if (!multiviewPresets || multiviewPresets.length === 0) {
       return null;
     }
-    handleUpdateMultiview({ ...multiviewPresets[0], for_pipeline_idx: 0 });
+    handleUpdateMultiview({
+      ...multiviewPresets[0],
+      for_pipeline_idx: 0
+    });
   }
 
   const handleSetSelectedMultiviewPreset = (name: string) => {
@@ -44,9 +48,10 @@ export default function MultiviewOutputSettings({
       toast.error(t('preset.no_multiview_found'));
       return;
     }
-    setetSelectedMultiviewPreset(selected);
+    setSelectedMultiviewPreset(selected);
     handleUpdateMultiview({ ...selected, for_pipeline_idx: 0 });
   };
+
   const getNumber = (val: string, prev: number) => {
     if (Number.isNaN(parseInt(val))) {
       return prev;
@@ -133,9 +138,12 @@ export default function MultiviewOutputSettings({
     : [];
 
   const multiviewOrPreset = multiview ? multiview : selectedMultiviewPreset;
+
   return (
     <div className="flex flex-col gap-2 rounded p-4">
-      <h1 className="font-bold">{t('preset.multiview_output_settings')}</h1>
+      <div className="flex justify-between">
+        <h1 className="font-bold">{t('preset.multiview_output_settings')}</h1>
+      </div>
       <Options
         label={t('preset.select_multiview_preset')}
         options={multiviewPresetNames}

--- a/src/components/startProduction/StartProductionButton.tsx
+++ b/src/components/startProduction/StartProductionButton.tsx
@@ -106,7 +106,7 @@ export function StartProductionButton({
             ),
             {
               ...pipelineToUpdateMultiview,
-              multiview: { ...multiviewPresets[0], for_pipeline_idx: 0 }
+              multiview: [{ ...multiviewPresets[0], for_pipeline_idx: 0 }]
             }
           ]
         }

--- a/src/hooks/multiviews.ts
+++ b/src/hooks/multiviews.ts
@@ -2,25 +2,33 @@ import { useState } from 'react';
 import { SourceReference } from '../interfaces/Source';
 import { CallbackHook } from './types';
 import { Production } from '../interfaces/production';
+import { MultiviewSettings } from '../interfaces/multiview';
 
 export function useMultiviews(): CallbackHook<
-  (pipelineId: string, production: Production, source: SourceReference) => void
+  (
+    pipelineId: string,
+    production: Production,
+    source: SourceReference,
+    singleMultiview: MultiviewSettings
+  ) => void
 > {
   const [loading, setLoading] = useState(true);
 
   const putMultiviewView = (
     pipelineId: string,
     production: Production,
-    source: SourceReference
+    source: SourceReference,
+    singleMultiview: MultiviewSettings
   ) => {
     setLoading(true);
 
-    const multiview = production.production_settings.pipelines[0].multiview;
-    if (!multiview) throw 'no multiview';
-    const rest = multiview.layout.views.filter(
+    if (!singleMultiview) throw 'no multiview';
+
+    const rest = singleMultiview.layout.views.filter(
       (v) => v.input_slot !== source.input_slot
     );
-    const viewsToUpdate = multiview.layout.views.filter(
+
+    const viewsToUpdate = singleMultiview.layout.views.filter(
       (v) => v.input_slot === source.input_slot
     );
     console.log(viewsToUpdate);
@@ -30,6 +38,7 @@ export function useMultiviews(): CallbackHook<
         label: source.label
       };
     });
+
     const restWithLabels = rest.map((view) => {
       const sourceForView = production.sources.find(
         (s) => s.input_slot === view.input_slot
@@ -40,15 +49,18 @@ export function useMultiviews(): CallbackHook<
       }
       return view;
     });
+
     if (!viewsToUpdate) {
       setLoading(false);
       return;
     }
+
     const updatedMultiviewViews = [
       ...restWithLabels,
       ...updatedViewsWithLabels
     ];
-    fetch(`/api/manager/multiviews/${multiview.multiview_id}`, {
+
+    fetch(`/api/manager/multiviews/${singleMultiview.multiview_id}`, {
       method: 'PUT',
       headers: [['x-api-key', `Bearer apisecretkey`]],
       body: JSON.stringify({
@@ -63,5 +75,6 @@ export function useMultiviews(): CallbackHook<
       })
       .finally(() => setLoading(false));
   };
+
   return [putMultiviewView, loading];
 }

--- a/src/interfaces/pipeline.ts
+++ b/src/interfaces/pipeline.ts
@@ -62,7 +62,7 @@ export interface PipelineSettings {
   audio_mapping: string;
   program_output_port: number; // deprecated but kept for backward compatibility
   program_output: ProgramOutput[];
-  multiview?: MultiviewSettings;
+  multiview?: MultiviewSettings[];
   interfaces: [
     {
       commit_rate: number;


### PR DESCRIPTION
# What does this do?
When setting up a production this allows for adding multiple multiviews to each production, for the possibility of having multiviews with different setups.

## Layout
Added buttons to add and remove additional multiviewers, when only one multiview remains the button is removed.
<img width="1787" alt="Screenshot 2024-08-27 at 13 42 00" src="https://github.com/user-attachments/assets/ccf68078-8249-452a-813e-5547d8bbd0c4">
